### PR TITLE
Adds basic Duplicate JSON Entry check

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: 'github-actions'
+    pull-request-branch-name:
+      separator: "-"
+    directory: '/'
+    schedule:
+      interval: 'daily'

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -6,7 +6,15 @@ jobs:
   verify-json-validation:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set up Node
+        uses: actions/setup-node@v3
+
+      - name: Validate JSON Files
+        run: node ./validate/index.js
+
       - name: Validate JSON
         uses: docker://orrosenblatt/validate-json-action:latest
         env:

--- a/README.md
+++ b/README.md
@@ -37,4 +37,12 @@ To add new data for your service
 
 The root of this project contains a `.pre-commit-config.yaml` file used with [pre-commit](https://pre-commit.com/) to automate the running of tasks when a commit is made with github.
 
+## Validation of JSON
+
+You can check the validity of your JSON document by running the following command in your terminal at the root of the project.
+
+`node ./validate/index.js`
+
+This also runs in the Github Action and will break the build if there is an error.
+
 OPG Services Performance Data: Managed by opg-org-infra &amp; Terraform

--- a/validate/index.js
+++ b/validate/index.js
@@ -1,0 +1,17 @@
+'use strict';
+
+const fs = require('fs');
+const documentsToCheck = ["./use-an-lpa/data.json", "./make-a-lpa/data.json"];
+
+documentsToCheck.forEach(value => {
+    const data = fs.readFileSync(value);
+    const parsedData = JSON.parse(data);
+
+    const duplicateDataSet = parsedData.map(v => v._timestamp + v.dataType);
+    const isDuplicate = duplicateDataSet.some((item, index) => index !== duplicateDataSet.indexOf(item));
+
+    if (isDuplicate) {
+        console.error(`JSON in ${value} has one or more entries with the same _timestamp and dataType. These need to be unique.`);
+        process.exit(1)
+    }
+})


### PR DESCRIPTION
Adds a script that runs in Github Actions to check for a duplicate entry containing the same `_timestamp` and `dataType`. 

This is a easy and common mistake to make and should hopefully help capture the error.

Also adds in dependabot for github actions. 

![image](https://user-images.githubusercontent.com/5390820/188849588-bb7d8678-9f36-4fb6-9d2b-e900a7965575.png)

![image](https://user-images.githubusercontent.com/5390820/188849775-20d335c3-fddb-4485-8b09-25a2c1c96337.png)
